### PR TITLE
Update Gemfile to force Jekyll version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,20 @@
 source 'https://rubygems.org'
-gem "github-pages", group: :jekyll_plugins
+gem "jekyll", "~> 4.3.3"
 
 group :jekyll_plugins do
   gem "jekyll-tidy"
 end
 
-gem "webrick", "~> 1.7"
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 ### Prerequisites
 
-- [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.2.5 or above, including all development headers (ruby installation can be checked by running `ruby -v`)
+- [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.5.0 or above, including all development headers (ruby installation can be checked by running `ruby -v`)
 - [RubyGems](https://rubygems.org/pages/download) (which you can check by running `gem -v`)
 - [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/) (in case your system doesn't have them installed, which you can check by running `gcc -v`,`g++ -v`  and `make -v` in your system's command line interface)
 
@@ -69,14 +69,6 @@ Just about any traditional web hosting provider will let you upload files to the
 * [Jekyl](https://jekyllrb.com/)
 * [Markdown](https://daringfireball.net/projects/markdown/)
 * [Liquid](https://shopify.github.io/liquid/)
-
-## Contact
-
-* [Frank Sträter](https://github.com/frankstrater)
-
-## Acknowledgments
-
-* [Siteleaf](https://www.siteleaf.com/?via=frank), an excellent Content Management System for Jekyll powered websites.
 
 ## License
 


### PR DESCRIPTION
To test this branch in an existings mediasuite-website install, checkout the branch with the changed Gemfile and run `bundle install` to get the upgraded gems.

Example. See jekyll gem version "Using jekyll 4.3.3 (was 3.9.2)":

```
frank@L348:~/projects/mediasuite-website$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Using rake 13.1.0
Using public_suffix 5.0.4 (was 4.0.7)
Using bundler 2.4.5
Using colorator 1.1.0
Using htmlcompressor 0.4.0
Using rb-fsevent 0.11.2
Using rexml 3.2.6 (was 3.2.5)
Using liquid 4.0.4 (was 4.0.3)
Using mercenary 0.4.0 (was 0.3.6)
Using rouge 4.2.1 (was 3.26.0)
Using safe_yaml 1.0.5
Using unicode-display_width 2.5.0 (was 1.8.0)
Using webrick 1.8.1
Using http_parser.rb 0.8.0
Using eventmachine 1.2.7
Using kramdown 2.4.0 (was 2.3.2)
Using ffi 1.16.3 (was 1.15.5)
Using terminal-table 3.0.2 (was 1.8.0)
Using forwardable-extended 2.6.0
Using em-websocket 0.5.3
Using kramdown-parser-gfm 1.1.0
Using rb-inotify 0.10.1
Using htmlbeautifier 1.4.2
Using addressable 2.8.6 (was 2.8.1)
Using concurrent-ruby 1.2.3 (was 1.2.0)
Using listen 3.9.0 (was 3.8.0)
Using pathutil 0.16.2
Using i18n 1.14.4 (was 0.9.5)
Using jekyll-watch 2.2.1
Using google-protobuf 3.25.3 (x86_64-linux)
Using sass-embedded 1.69.5
Using jekyll-sass-converter 3.0.0 (was 1.5.2)
Using jekyll 4.3.3 (was 3.9.2)
Using jekyll-tidy 0.2.2
Bundle complete! 6 Gemfile dependencies, 34 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```